### PR TITLE
use reference when writing blocks

### DIFF
--- a/examples/kmer_count2kff.rs
+++ b/examples/kmer_count2kff.rs
@@ -101,7 +101,7 @@ fn main() -> error::Result<()> {
     values.insert("data_size".to_string(), 1);
 
     kff.write_values(values.clone())?;
-    kff.write_raw(kff::section::Raw::new(&values)?, kmers)?;
+    kff.write_raw(kff::section::Raw::new(&values)?, &kmers)?;
     kff.finalize()?;
     log::info!("End create kff file");
 

--- a/src/kff.rs
+++ b/src/kff.rs
@@ -251,7 +251,7 @@ where
     pub fn write_raw(
         &mut self,
         raw: section::Raw,
-        blocks: Vec<section::block::Block>,
+        blocks: &Vec<section::block::Block>,
     ) -> error::Result<()> {
         self.inner.write_bytes(b"r")?;
         raw.write(&mut self.inner, blocks)
@@ -262,7 +262,7 @@ where
         &mut self,
         section: section::Minimizer,
         minimizer: crate::Seq2Bit,
-        blocks: Vec<section::block::Block>,
+        blocks: &Vec<section::block::Block>,
     ) -> error::Result<()> {
         self.inner.write_bytes(b"m")?;
         section.write(&mut self.inner, minimizer, blocks)
@@ -412,7 +412,7 @@ mod tests {
 
         writer.write_values(values.clone())?;
 
-        writer.write_raw(section::Raw::new(&values)?, vec![
+        writer.write_raw(section::Raw::new(&values)?, &vec![
 	    section::block::Block {
                 k: 5,
                 data_size: 1,
@@ -442,7 +442,7 @@ mod tests {
         writer.write_minimizer(
 	    section::Minimizer::new(&values)?,
 	    bitvec::bitbox![u8, bitvec::order::Msb0; 0, 1, 1, 0, 1, 1],
-            vec![
+            &vec![
                 section::block::Block{
                     k: 5,
                     data_size: 1,

--- a/src/section/minimizer.rs
+++ b/src/section/minimizer.rs
@@ -90,7 +90,7 @@ impl Minimizer {
         &self,
         outer: &mut W,
         minimizer: Seq2Bit,
-        blocks: Vec<section::block::Block>,
+        blocks: &Vec<section::block::Block>,
     ) -> error::Result<()>
     where
         W: std::io::Write + crate::KffWrite,
@@ -207,7 +207,7 @@ mod tests {
         minimizer.write(
             &mut writable,
 	    bitvec::bitbox![u8, bitvec::order::Msb0; 0, 1, 1, 0, 1, 1],
-            vec![
+            &vec![
                 section::block::Block{
                     k: 5,
                     data_size: 1,

--- a/src/section/raw.rs
+++ b/src/section/raw.rs
@@ -71,7 +71,7 @@ impl Raw {
     }
 
     /// Write a Raw section, section flag isn't write
-    pub fn write<W>(&self, outer: &mut W, blocks: Vec<section::block::Block>) -> error::Result<()>
+    pub fn write<W>(&self, outer: &mut W, blocks: &Vec<section::block::Block>) -> error::Result<()>
     where
         W: std::io::Write + crate::KffWrite,
     {
@@ -178,7 +178,7 @@ mod tests {
 
         raw.write(
             &mut writable,
-            vec![
+            &vec![
                 section::block::Block {
                     k: 5,
                     data_size: 1,


### PR DESCRIPTION
Using a reference when writing my blocks vector would allow me to reuse their memory, e.g. when in a loop.